### PR TITLE
Bump version number to 1.1.2

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -1,6 +1,6 @@
 package:
   name: sisppeo
-  version: 1.1.1
+  version: 1.1.2
 
 source:
   path: ..

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def readme():
 
 setup(
     name='SISPPEO',
-    version='1.1.1',
+    version='1.1.2',
     description='Satellite Imagery & Signal Processing Packages for Earth Observation',
     long_description=readme(),
     url='https://github.com/inrae/SISPPEO',

--- a/sisppeo/_version.py
+++ b/sisppeo/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'


### PR DESCRIPTION
Avoid conflicts between the [source's versions](https://github.com/inrae/SISPPEO/releases) and [anaconda's versions](https://anaconda.org/conda-forge/sisppeo/labels):

1. Branch main is `v1.1.0` in source but the main label is `v1.1.1` in anaconda.
2. Branch cnes is `v1.1.1` in source but the cnes label is also `v1.1.1` in anaconda.

The v1.1.1 on the cnes branch do not modify the core library. One could then argue that creating a new build without modifying the version is a solution. However the fact that the main version on source and anaconda are desynced justify this PR imo.

History of the changes made that created the conflict:
- https://github.com/conda-forge/sisppeo-feedstock/pull/2
- https://github.com/conda-forge/sisppeo-feedstock/pull/3
- https://github.com/conda-forge/sisppeo-feedstock/pull/4/
- https://github.com/conda-forge/sisppeo-feedstock/pull/6